### PR TITLE
Don't set dark theme when installed

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -6,7 +6,6 @@ const {Services} = Cu.import("resource://gre/modules/Services.jsm");
 const {LightweightThemeManager} = Cu.import("resource://gre/modules/LightweightThemeManager.jsm");
 
 function install() {
-  Services.prefs.setCharPref("devtools.theme", "dark");
   LightweightThemeManager.currentTheme = LightweightThemeManager.getUsedTheme("firefox-devedition@mozilla.org");
 }
 


### PR DESCRIPTION
Some of us prefer it light, and already have the theme set to light in the devtools options. It would probably be useful to just put a little screenshot / tutorial on the homepage, or add the setting to the addon settings page as well.
